### PR TITLE
fix(order): align OrderFulfillment feature flag name across config an…

### DIFF
--- a/Src/Services/Order/Order.API/appsettings.json
+++ b/Src/Services/Order/Order.API/appsettings.json
@@ -8,7 +8,7 @@
     "Password": "guest"
   },
   "FeatureManagement": {
-    "OrderFullfilment": false
+    "OrderFulfillment": false
   },
   "Logging": {
     "LogLevel": {

--- a/Src/Services/Order/Order.Application/FeatureFlags.cs
+++ b/Src/Services/Order/Order.Application/FeatureFlags.cs
@@ -1,0 +1,9 @@
+namespace Order.Application;
+
+/// <summary>
+/// Centralizes feature flag keys so config, code, and deployment files reference the same name.
+/// </summary>
+public static class FeatureFlags
+{
+    public const string OrderFulfillment = "OrderFulfillment";
+}

--- a/Src/Services/Order/Order.Application/OrdersCQRS/EventHandlers/Domain/OrderCreateEventHandler.cs
+++ b/Src/Services/Order/Order.Application/OrdersCQRS/EventHandlers/Domain/OrderCreateEventHandler.cs
@@ -6,7 +6,7 @@ namespace Order.Application.OrdersCQRS.EventHandlers.Domain;
 
 /// <summary>
 /// Handles the domain event when a new order is created.
-/// Publishes an integration event if the OrderFullfillment feature is enabled.
+/// Publishes an integration event if the OrderFulfillment feature is enabled.
 /// </summary>
 /// <param name="publishEndpoint">Endpoint used to publish integration events to the message bus.</param>
 /// <param name="featureManager">Manages feature flags to enable/disable runtime behaviors.</param>
@@ -17,7 +17,7 @@ public class OrderCreateEventHandler(IPublishEndpoint publishEndpoint, IFeatureM
     {
         logger.LogInformation("Domain Evenet handled : {DomainEvent}",domainEvent.GetType().Name);
 
-        if (await featureManager.IsEnabledAsync("OrderFullfillment"))
+        if (await featureManager.IsEnabledAsync(FeatureFlags.OrderFulfillment))
         {
             var orderCreateIntegrationEvent = domainEvent.order.ToOrderDto();
             await publishEndpoint.Publish(orderCreateIntegrationEvent, cancellationToken);

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -110,7 +110,7 @@ services:
       - MessageBroker__Host=amqp://ecommerce-mq:5672
       - MessageBroker__UserName=guest
       - MessageBroker__Password=guest
-      - FeatureManagement__OrderFullfilment=false
+      - FeatureManagement__OrderFulfillment=false
     depends_on:
       - orderdb
       - messagebroker


### PR DESCRIPTION
…d code

The feature manager checked "OrderFullfillment" while config/compose used "OrderFullfilment", so the flag could never be enabled. Standardize on the correct spelling "OrderFulfillment" and introduce a FeatureFlags constant to remove the magic string.