### PR TITLE
fix(basket): guard against corrupt or null cached basket

### DIFF
--- a/Src/Services/Basket/BasketAPI/Data/CachedBasketRepository.cs
+++ b/Src/Services/Basket/BasketAPI/Data/CachedBasketRepository.cs
@@ -13,11 +13,24 @@ public class CachedBasketRepository(IBasketRepository repository, IDistributedCa
     {
         var cachedBasket = await cache.GetStringAsync(userName, cancellationToken);
         if (!string.IsNullOrEmpty(cachedBasket))
-            return JsonSerializer.Deserialize<ShoppingCard>(cachedBasket);
+        {
+            var deserialized = TryDeserialize(cachedBasket);
+            if (deserialized is not null)
+                return deserialized;
+
+            // Corrupt cache entry: drop it and fall back to the repository.
+            await cache.RemoveAsync(userName, cancellationToken);
+        }
 
         var basket = await repository.GetBasket(userName, cancellationToken);
         await cache.SetStringAsync(userName, JsonSerializer.Serialize(basket), cancellationToken);
         return basket;
+    }
+
+    private static ShoppingCard? TryDeserialize(string json)
+    {
+        try { return JsonSerializer.Deserialize<ShoppingCard>(json); }
+        catch (JsonException) { return null; }
     }
 
     public async Task<ShoppingCard> StoreBasket(ShoppingCard basket, CancellationToken cancellationToken = default)


### PR DESCRIPTION
GetBasket returned JsonSerializer.Deserialize directly, which can be null and break the non-null contract. Deserialize safely; on corrupt cache, drop the entry and fall back to the repository.