### PR TITLE
fix(messaging): stabilize IntegrationEvent id and OccuredOn

### DIFF
--- a/Src/BuildingBlocks/BuildingBlockMessaging/Events/IntegrationEvent.cs
+++ b/Src/BuildingBlocks/BuildingBlockMessaging/Events/IntegrationEvent.cs
@@ -2,7 +2,8 @@
 
 public record IntegrationEvent
 {
-    public Guid id => Guid.NewGuid(); 
-    public DateTime OccuredOn => DateTime.UtcNow;
-    public string EventType => GetType().AssemblyQualifiedName;
+    // Assigned once at construction so the event keeps a stable id/timestamp.
+    public Guid id { get; init; } = Guid.NewGuid();
+    public DateTime OccuredOn { get; init; } = DateTime.UtcNow;
+    public string EventType => GetType().AssemblyQualifiedName!;
 }


### PR DESCRIPTION
id and OccuredOn were expression-bodied and recomputed on every read, breaking correlation/idempotency. Make them init-only auto-properties assigned once at construction; keep property names to preserve serialization.