### PR TITLE
feat(gateway): containerize gateway and orchestrate full stack in doc…

### DIFF
--- a/Src/ApiGateways/YarpApiGateway/Dockerfile
+++ b/Src/ApiGateways/YarpApiGateway/Dockerfile
@@ -13,6 +13,7 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Src/ApiGateways/YarpApiGateway/YarpApiGateway.csproj", "Src/ApiGateways/YarpApiGateway/"]
+COPY ["Src/BuildingBlocks/BuildingBlock/BuildingBlock.csproj", "Src/BuildingBlocks/BuildingBlock/"]
 RUN dotnet restore "./Src/ApiGateways/YarpApiGateway/YarpApiGateway.csproj"
 COPY . .
 WORKDIR "/src/Src/ApiGateways/YarpApiGateway"

--- a/Src/ApiGateways/YarpApiGateway/Program.cs
+++ b/Src/ApiGateways/YarpApiGateway/Program.cs
@@ -1,4 +1,5 @@
 using BuildingBlock.Logging;
+using BuildingBlock.Observability;
 using Microsoft.AspNetCore.RateLimiting;
 using Serilog;
 
@@ -7,6 +8,9 @@ var builder = WebApplication.CreateBuilder(args);
 
 //Serilog host (shared standard config: console + optional Seq)
 builder.Host.UseStandardSerilog("YarpApiGateway");
+
+//OpenTelemetry traces + metrics (OTLP)
+builder.Services.AddStandardOpenTelemetry("YarpApiGateway");
 
 builder.Services.AddReverseProxy()
     .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));

--- a/Src/ApiGateways/YarpApiGateway/Program.cs
+++ b/Src/ApiGateways/YarpApiGateway/Program.cs
@@ -1,7 +1,12 @@
+using BuildingBlock.Logging;
 using Microsoft.AspNetCore.RateLimiting;
+using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
 // Add services to the conatiner.
+
+//Serilog host (shared standard config: console + optional Seq)
+builder.Host.UseStandardSerilog("YarpApiGateway");
 
 builder.Services.AddReverseProxy()
     .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
@@ -20,6 +25,8 @@ builder.Services.AddHealthChecks();
 
 var app = builder.Build();
 // Configure the HTTP request pipeline.
+
+app.UseSerilogRequestLogging();
 
 // RateLimit pipeline
 app.UseRateLimiter();

--- a/Src/ApiGateways/YarpApiGateway/YarpApiGateway.csproj
+++ b/Src/ApiGateways/YarpApiGateway/YarpApiGateway.csproj
@@ -14,4 +14,8 @@
     <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\BuildingBlocks\BuildingBlock\BuildingBlock.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Src/ApiGateways/YarpApiGateway/appsettings.json
+++ b/Src/ApiGateways/YarpApiGateway/appsettings.json
@@ -8,12 +8,6 @@
   "AllowedHosts": "*",
   "ReverseProxy": {
     "Routes": {
-      "route1": {
-        "ClusterId": "cluster1",
-        "Match": {
-          "Path": "{**catch-all}"
-        }
-      },
       "catalog-route": {
         "ClusterId": "catalog-cluster",
         "Match": {
@@ -38,13 +32,6 @@
       }
     },
     "Clusters": {
-      "cluster1": {
-        "Destinations": {
-          "destination1": {
-            "Address": "http://localhost:6000/products"
-          }
-        }
-      },
       "catalog-cluster": {
         "Destinations": {
           "destination1": {

--- a/Src/BuildingBlocks/BuildingBlock/BuildingBlock.csproj
+++ b/Src/BuildingBlocks/BuildingBlock/BuildingBlock.csproj
@@ -16,6 +16,11 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="8.0.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
   </ItemGroup>
 
 </Project>

--- a/Src/BuildingBlocks/BuildingBlock/BuildingBlock.csproj
+++ b/Src/BuildingBlocks/BuildingBlock/BuildingBlock.csproj
@@ -12,6 +12,10 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageReference Include="Mapster" Version="7.4.0" />
     <PackageReference Include="MediatR" Version="12.4.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Src/BuildingBlocks/BuildingBlock/Logging/SerilogExtensions.cs
+++ b/Src/BuildingBlocks/BuildingBlock/Logging/SerilogExtensions.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Hosting;
+using Serilog;
+using Serilog.Events;
+using Serilog.Formatting.Compact;
+
+namespace BuildingBlock.Logging;
+
+public static class SerilogExtensions
+{
+    // Standard structured logging for every service: compact JSON to console plus an optional
+    // Seq sink, enriched with ServiceName and the current trace/span ids for log-trace correlation.
+    public static IHostBuilder UseStandardSerilog(this IHostBuilder host, string serviceName) =>
+        host.UseSerilog((context, loggerConfig) =>
+        {
+            loggerConfig
+                .MinimumLevel.Information()
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+                .Enrich.FromLogContext()
+                .Enrich.WithProperty("ServiceName", serviceName)
+                .WriteTo.Console(new RenderedCompactJsonFormatter());
+
+            // Seq is optional: without configuration the service still logs to console (host dev).
+            var seqUrl = context.Configuration["Seq:ServerUrl"];
+            if (!string.IsNullOrWhiteSpace(seqUrl))
+                loggerConfig.WriteTo.Seq(seqUrl);
+        });
+}

--- a/Src/BuildingBlocks/BuildingBlock/Logging/SerilogExtensions.cs
+++ b/Src/BuildingBlocks/BuildingBlock/Logging/SerilogExtensions.cs
@@ -1,9 +1,25 @@
+using System.Diagnostics;
 using Microsoft.Extensions.Hosting;
 using Serilog;
+using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting.Compact;
 
 namespace BuildingBlock.Logging;
+
+// Adds the current Activity's TraceId/SpanId to each log event so logs link to OpenTelemetry traces.
+internal sealed class ActivityEnricher : ILogEventEnricher
+{
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory factory)
+    {
+        var activity = Activity.Current;
+        if (activity is null)
+            return;
+
+        logEvent.AddPropertyIfAbsent(factory.CreateProperty("TraceId", activity.TraceId.ToString()));
+        logEvent.AddPropertyIfAbsent(factory.CreateProperty("SpanId", activity.SpanId.ToString()));
+    }
+}
 
 public static class SerilogExtensions
 {
@@ -17,6 +33,7 @@ public static class SerilogExtensions
                 .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
                 .Enrich.FromLogContext()
                 .Enrich.WithProperty("ServiceName", serviceName)
+                .Enrich.With(new ActivityEnricher())
                 .WriteTo.Console(new RenderedCompactJsonFormatter());
 
             // Seq is optional: without configuration the service still logs to console (host dev).

--- a/Src/BuildingBlocks/BuildingBlock/Observability/OpenTelemetryExtensions.cs
+++ b/Src/BuildingBlocks/BuildingBlock/Observability/OpenTelemetryExtensions.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace BuildingBlock.Observability;
+
+public static class OpenTelemetryExtensions
+{
+    // Standard tracing + metrics for every service. The OTLP exporter reads its target from the
+    // OTEL_EXPORTER_OTLP_ENDPOINT env var; when unset (host dev) it stays a no-op.
+    public static IServiceCollection AddStandardOpenTelemetry(this IServiceCollection services, string serviceName)
+    {
+        services.AddOpenTelemetry()
+            .ConfigureResource(resource => resource.AddService(serviceName))
+            .WithTracing(tracing => tracing
+                .AddAspNetCoreInstrumentation()
+                .AddHttpClientInstrumentation()
+                .AddSource("MassTransit")   // checkout integration-event flow (Basket -> Order)
+                .AddSource("Npgsql")        // Marten/PostgreSQL (Catalog, Basket)
+                .AddOtlpExporter())
+            .WithMetrics(metrics => metrics
+                .AddAspNetCoreInstrumentation()
+                .AddHttpClientInstrumentation()
+                .AddRuntimeInstrumentation()
+                .AddOtlpExporter());
+
+        return services;
+    }
+}

--- a/Src/Services/Basket/BasketAPI/Program.cs
+++ b/Src/Services/Basket/BasketAPI/Program.cs
@@ -1,6 +1,8 @@
 ﻿using BasketAPI.CheckoutSaga;
 using BuildingBlock.Exceptions.Handlers;
+using BuildingBlock.Logging;
 using DiscountGrpc.Protos;
+using Serilog;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
@@ -14,6 +16,8 @@ public class Program
     {
         var builder = WebApplication.CreateBuilder(args);
 
+        //Serilog host (shared standard config: console + optional Seq)
+        builder.Host.UseStandardSerilog("BasketAPI");
 
         //MediatR config
         var assembly = typeof(Program).Assembly;
@@ -104,6 +108,7 @@ public class Program
         var app = builder.Build();
 
         // Configure the HTTP request pipeline.
+        app.UseSerilogRequestLogging();
         app.MapCarter();
         app.UseExceptionHandler(options => { });
         app.UseHealthChecks("/health",

--- a/Src/Services/Basket/BasketAPI/Program.cs
+++ b/Src/Services/Basket/BasketAPI/Program.cs
@@ -1,6 +1,7 @@
 ﻿using BasketAPI.CheckoutSaga;
 using BuildingBlock.Exceptions.Handlers;
 using BuildingBlock.Logging;
+using BuildingBlock.Observability;
 using DiscountGrpc.Protos;
 using Serilog;
 using HealthChecks.UI.Client;
@@ -18,6 +19,9 @@ public class Program
 
         //Serilog host (shared standard config: console + optional Seq)
         builder.Host.UseStandardSerilog("BasketAPI");
+
+        //OpenTelemetry traces + metrics (OTLP)
+        builder.Services.AddStandardOpenTelemetry("BasketAPI");
 
         //MediatR config
         var assembly = typeof(Program).Assembly;

--- a/Src/Services/CatalogAPI/Program.cs
+++ b/Src/Services/CatalogAPI/Program.cs
@@ -1,4 +1,5 @@
 using BuildingBlock.Logging;
+using BuildingBlock.Observability;
 
 //The reason of the typeof(Program).Assembly to provide to run commands and queriesd only in this progran.cs
 var assembly = typeof(Program).Assembly;
@@ -23,6 +24,9 @@ try
 
     //Serilog host (shared standard config: console + optional Seq)
     builder.Host.UseStandardSerilog("CatalogAPI");
+
+    //OpenTelemetry traces + metrics (OTLP)
+    builder.Services.AddStandardOpenTelemetry("CatalogAPI");
 
     var connString = builder.Configuration.GetConnectionString("PostgreDataBase");
 

--- a/Src/Services/CatalogAPI/Program.cs
+++ b/Src/Services/CatalogAPI/Program.cs
@@ -1,13 +1,7 @@
+using BuildingBlock.Logging;
+
 //The reason of the typeof(Program).Assembly to provide to run commands and queriesd only in this progran.cs
 var assembly = typeof(Program).Assembly;
-
-Log.Logger = new LoggerConfiguration()
-    .MinimumLevel.Information()
-    .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
-    .Enrich.FromLogContext()
-    .Enrich.WithProperty("ServiceName", "CatalogAPI")
-    .WriteTo.Console(new RenderedCompactJsonFormatter())
-    .CreateLogger();
 
 try
 {
@@ -27,8 +21,8 @@ try
     builder.Services.AddValidatorsFromAssembly(assembly);
     builder.Services.AddCarter();
 
-    //Serilog host
-    builder.Host.UseSerilog();
+    //Serilog host (shared standard config: console + optional Seq)
+    builder.Host.UseStandardSerilog("CatalogAPI");
 
     var connString = builder.Configuration.GetConnectionString("PostgreDataBase");
 

--- a/Src/Services/DiscountGrpc/DiscountGrpc.csproj
+++ b/Src/Services/DiscountGrpc/DiscountGrpc.csproj
@@ -29,4 +29,8 @@
 		<Protobuf Include="Protos\discount.proto" GrpcServices="Server" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<ProjectReference Include="..\..\BuildingBlocks\BuildingBlock\BuildingBlock.csproj" />
+	</ItemGroup>
+
 </Project>

--- a/Src/Services/DiscountGrpc/Dockerfile
+++ b/Src/Services/DiscountGrpc/Dockerfile
@@ -13,6 +13,7 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Src/Services/DiscountGrpc/DiscountGrpc.csproj", "Src/Services/DiscountGrpc/"]
+COPY ["Src/BuildingBlocks/BuildingBlock/BuildingBlock.csproj", "Src/BuildingBlocks/BuildingBlock/"]
 RUN dotnet restore "./Src/Services/DiscountGrpc/DiscountGrpc.csproj"
 COPY . .
 WORKDIR "/src/Src/Services/DiscountGrpc"

--- a/Src/Services/DiscountGrpc/Program.cs
+++ b/Src/Services/DiscountGrpc/Program.cs
@@ -1,8 +1,13 @@
+using BuildingBlock.Logging;
 using DiscountGrpc.Data;
 using DiscountGrpc.Services;
 using Microsoft.EntityFrameworkCore;
+using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
+
+//Serilog host (shared standard config: console + optional Seq)
+builder.Host.UseStandardSerilog("DiscountGrpc");
 
 // Add services to the container.
 builder.Services.AddGrpc();
@@ -15,6 +20,7 @@ builder.Services.AddHealthChecks();
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
+app.UseSerilogRequestLogging();
 app.UseMigration();
 app.MapHealthChecks("/health");
 // Map the gRPC service to the application's request pipeline, allowing it to handle incoming gRPC requests.

--- a/Src/Services/DiscountGrpc/Program.cs
+++ b/Src/Services/DiscountGrpc/Program.cs
@@ -1,4 +1,5 @@
 using BuildingBlock.Logging;
+using BuildingBlock.Observability;
 using DiscountGrpc.Data;
 using DiscountGrpc.Services;
 using Microsoft.EntityFrameworkCore;
@@ -8,6 +9,9 @@ var builder = WebApplication.CreateBuilder(args);
 
 //Serilog host (shared standard config: console + optional Seq)
 builder.Host.UseStandardSerilog("DiscountGrpc");
+
+//OpenTelemetry traces + metrics (OTLP)
+builder.Services.AddStandardOpenTelemetry("DiscountGrpc");
 
 // Add services to the container.
 builder.Services.AddGrpc();

--- a/Src/Services/Order/Order.API/Program.cs
+++ b/Src/Services/Order/Order.API/Program.cs
@@ -1,8 +1,13 @@
 
+using BuildingBlock.Logging;
 using Order.Infrastructure.Data.Extentions;
+using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
-// Add services to the container 
+// Add services to the container
+
+//Serilog host (shared standard config: console + optional Seq)
+builder.Host.UseStandardSerilog("Order.API");
 
 builder.Services
     .AddApplicationServices(builder.Configuration)
@@ -11,6 +16,7 @@ builder.Services
 
 var app = builder.Build();
 
+app.UseSerilogRequestLogging();
 app.UseApiServices();
 
 if (app.Environment.IsDevelopment())

--- a/Src/Services/Order/Order.API/Program.cs
+++ b/Src/Services/Order/Order.API/Program.cs
@@ -1,5 +1,6 @@
 
 using BuildingBlock.Logging;
+using BuildingBlock.Observability;
 using Order.Infrastructure.Data.Extentions;
 using Serilog;
 
@@ -8,6 +9,9 @@ var builder = WebApplication.CreateBuilder(args);
 
 //Serilog host (shared standard config: console + optional Seq)
 builder.Host.UseStandardSerilog("Order.API");
+
+//OpenTelemetry traces + metrics (OTLP)
+builder.Services.AddStandardOpenTelemetry("Order.API");
 
 builder.Services
     .AddApplicationServices(builder.Configuration)

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -10,6 +10,11 @@ services:
       - postgres_catalog:/var/lib/postgresql/data
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d CatalogDb"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   basketdb:
     container_name: basketdb
@@ -21,22 +26,38 @@ services:
     ports:
       - "5433:5432"
     volumes:
-      - postgres_basket:/var/lib/postgresql/data 
-    
+      - postgres_basket:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d BasketDb"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   orderdb:
     container_name: orderdb
-    environment: 
+    environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=MyDb1234!
     restart: always
     ports:
       - "1433:1433"
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$$SA_PASSWORD\" -C -Q 'SELECT 1' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
 
   distributedcache:
     container_name: distributedcache
     restart: always
     ports:
       - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 # ---------------- Services ---------------------
   catalogapi:
@@ -45,8 +66,9 @@ services:
       - ASPNETCORE_HTTP_PORTS=8080
       - ASPNETCORE_HTTPS_PORTS=8081
       - ConnectionStrings__PostgreDataBase=Server=catalogdb;Port=5432;Database=CatalogDb;User Id=postgres;Password=postgres;Include Error Detail=true
-    depends_on: 
-      - catalogdb
+    depends_on:
+      catalogdb:
+        condition: service_healthy
     ports:
       - "6000:8080"
       - "6060:8081"
@@ -66,10 +88,14 @@ services:
       - MessageBroker__UserName=guest
       - MessageBroker__Password=guest
     depends_on:
-      - basketdb
-      - distributedcache
-      - discountgrpc
-      - messagebroker
+      basketdb:
+        condition: service_healthy
+      distributedcache:
+        condition: service_healthy
+      discountgrpc:
+        condition: service_started
+      messagebroker:
+        condition: service_healthy
     ports:
       - "6001:8080"
       - "6061:8081"
@@ -96,11 +122,17 @@ services:
     environment:
       - RABBITMQ_DEFAULT_USER=guest
       - RABBITMQ_DEFAULT_PASS=guest
-    restart: always 
+    restart: always
     ports:
       - "5672:5672"
-      - "15672:15672" 
-   
+      - "15672:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
+
   order.api:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
@@ -112,8 +144,10 @@ services:
       - MessageBroker__Password=guest
       - FeatureManagement__OrderFulfillment=false
     depends_on:
-      - orderdb
-      - messagebroker
+      orderdb:
+        condition: service_healthy
+      messagebroker:
+        condition: service_healthy
     ports:
       - "6003:8080"
       - "6063:8081"
@@ -122,3 +156,19 @@ services:
       - ${APPDATA}/Microsoft/UserSecrets:/root/.microsoft/usersecrets:ro
       - ${APPDATA}/ASP.NET/Https:/home/app/.aspnet/https:ro
       - ${APPDATA}/ASP.NET/Https:/root/.aspnet/https:ro
+
+  yarpapigateway:
+    container_name: yarpapigateway
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_HTTP_PORTS=8080
+      # Container-network destinations override the localhost values in appsettings (host dev).
+      - ReverseProxy__Clusters__catalog-cluster__Destinations__destination1__Address=http://catalogapi:8080/
+      - ReverseProxy__Clusters__basket-cluster__Destinations__destination1__Address=http://basketapi:8080/
+      - ReverseProxy__Clusters__ordering-cluster__Destinations__destination1__Address=http://order.api:8080/
+    depends_on:
+      - catalogapi
+      - basketapi
+      - order.api
+    ports:
+      - "5004:8080"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -68,6 +68,15 @@ services:
       - "5341:5341"   # ingestion
       - "8081:80"     # UI
 
+  otel-dashboard:
+    container_name: otel-dashboard
+    environment:
+      - DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true   # dev only: no login token
+    restart: always
+    ports:
+      - "18888:18888"   # UI (traces/metrics/logs)
+      - "18889:18889"   # OTLP gRPC ingestion
+
 # ---------------- Services ---------------------
   catalogapi:
     environment:
@@ -76,6 +85,7 @@ services:
       - ASPNETCORE_HTTPS_PORTS=8081
       - ConnectionStrings__PostgreDataBase=Server=catalogdb;Port=5432;Database=CatalogDb;User Id=postgres;Password=postgres;Include Error Detail=true
       - Seq__ServerUrl=http://seq:5341
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-dashboard:18889
     depends_on:
       catalogdb:
         condition: service_healthy
@@ -98,6 +108,7 @@ services:
       - MessageBroker__UserName=guest
       - MessageBroker__Password=guest
       - Seq__ServerUrl=http://seq:5341
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-dashboard:18889
     depends_on:
       basketdb:
         condition: service_healthy
@@ -121,6 +132,7 @@ services:
       - ASPNETCORE_HTTPS_PORTS=8081
       - ConnectionStrings__Database=Data Source=discountdb
       - Seq__ServerUrl=http://seq:5341
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-dashboard:18889
     ports:
       - "6002:8080"
       - "6062:8081"
@@ -156,6 +168,7 @@ services:
       - MessageBroker__Password=guest
       - FeatureManagement__OrderFulfillment=false
       - Seq__ServerUrl=http://seq:5341
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-dashboard:18889
     depends_on:
       orderdb:
         condition: service_healthy
@@ -180,6 +193,7 @@ services:
       - ReverseProxy__Clusters__basket-cluster__Destinations__destination1__Address=http://basketapi:8080/
       - ReverseProxy__Clusters__ordering-cluster__Destinations__destination1__Address=http://order.api:8080/
       - Seq__ServerUrl=http://seq:5341
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-dashboard:18889
     depends_on:
       - catalogapi
       - basketapi

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -59,6 +59,15 @@ services:
       timeout: 5s
       retries: 5
 
+  seq:
+    container_name: seq
+    environment:
+      - ACCEPT_EULA=Y
+    restart: always
+    ports:
+      - "5341:5341"   # ingestion
+      - "8081:80"     # UI
+
 # ---------------- Services ---------------------
   catalogapi:
     environment:
@@ -66,6 +75,7 @@ services:
       - ASPNETCORE_HTTP_PORTS=8080
       - ASPNETCORE_HTTPS_PORTS=8081
       - ConnectionStrings__PostgreDataBase=Server=catalogdb;Port=5432;Database=CatalogDb;User Id=postgres;Password=postgres;Include Error Detail=true
+      - Seq__ServerUrl=http://seq:5341
     depends_on:
       catalogdb:
         condition: service_healthy
@@ -87,6 +97,7 @@ services:
       - MessageBroker__Host=amqp://ecommerce-mq:5672
       - MessageBroker__UserName=guest
       - MessageBroker__Password=guest
+      - Seq__ServerUrl=http://seq:5341
     depends_on:
       basketdb:
         condition: service_healthy
@@ -109,6 +120,7 @@ services:
       - ASPNETCORE_HTTP_PORTS=8080
       - ASPNETCORE_HTTPS_PORTS=8081
       - ConnectionStrings__Database=Data Source=discountdb
+      - Seq__ServerUrl=http://seq:5341
     ports:
       - "6002:8080"
       - "6062:8081"
@@ -143,6 +155,7 @@ services:
       - MessageBroker__UserName=guest
       - MessageBroker__Password=guest
       - FeatureManagement__OrderFulfillment=false
+      - Seq__ServerUrl=http://seq:5341
     depends_on:
       orderdb:
         condition: service_healthy
@@ -166,6 +179,7 @@ services:
       - ReverseProxy__Clusters__catalog-cluster__Destinations__destination1__Address=http://catalogapi:8080/
       - ReverseProxy__Clusters__basket-cluster__Destinations__destination1__Address=http://basketapi:8080/
       - ReverseProxy__Clusters__ordering-cluster__Destinations__destination1__Address=http://order.api:8080/
+      - Seq__ServerUrl=http://seq:5341
     depends_on:
       - catalogapi
       - basketapi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,9 @@ services:
       context: .
       dockerfile: Src/ApiGateways/YarpApiGateway/Dockerfile
 
+  seq:
+    image: datalust/seq:latest
+
 volumes:
   postgres_catalog:
   postgres_basket:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,12 @@ services:
       context: .
       dockerfile: Src/Services/Order/Order.API/Dockerfile
 
+  yarpapigateway:
+    image: ${DOCKER_REGISTRY-}yarpapigateway
+    build:
+      context: .
+      dockerfile: Src/ApiGateways/YarpApiGateway/Dockerfile
+
 volumes:
   postgres_catalog:
   postgres_basket:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,9 @@ services:
   seq:
     image: datalust/seq:latest
 
+  otel-dashboard:
+    image: mcr.microsoft.com/dotnet/aspire-dashboard:9.0
+
 volumes:
   postgres_catalog:
   postgres_basket:


### PR DESCRIPTION
…ker-compose

Add yarpapigateway to docker-compose; override YARP cluster destinations to container DNS (catalogapi/basketapi/order.api:8080) so the gateway works inside the compose network while appsettings keeps localhost for host dev. Add healthchecks (postgres/mssql/redis/rabbitmq) and depends_on: service_healthy so services wait for their dependencies. Remove the catch-all route that silently proxied unmatched paths to catalog.